### PR TITLE
New Logging Engine

### DIFF
--- a/src/main/dist/bin/build.gradle
+++ b/src/main/dist/bin/build.gradle
@@ -419,7 +419,6 @@ task reload {
         }
       }
     }
-    
     generateSilverpeasFinalWar(log)
 
     try {

--- a/src/main/dist/configuration/jboss/jackrabbit-ra.cli
+++ b/src/main/dist/configuration/jboss/jackrabbit-ra.cli
@@ -3,6 +3,9 @@
 #
 
 if (outcome != success) of /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar:read-resource
+  # Start batching commands
+   batch
+
   /subsystem=jca/archive-validation=archive-validation:write-attribute(name=enabled, value=false)
 
   /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar:add(archive=jackrabbit-jca.rar,transaction-support=XATransaction)
@@ -13,6 +16,9 @@ if (outcome != success) of /subsystem=resource-adapters/resource-adapter=jackrab
   /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar/connection-definitions=cfName/config-properties=ConfigFile/:add(value=${JCR_HOME}/repository.xml)
 
   /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar/connection-definitions=cfName/config-properties=HomeDir/:add(value=${JCR_HOME})
+
+  # Run the batch commands
+  run-batch
 end-if
 
 

--- a/src/main/dist/configuration/jboss/jackrabbit-ra.cli
+++ b/src/main/dist/configuration/jboss/jackrabbit-ra.cli
@@ -3,8 +3,6 @@
 #
 
 if (outcome != success) of /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar:read-resource
-  # Start batching commands
-   batch
 
   /subsystem=jca/archive-validation=archive-validation:write-attribute(name=enabled, value=false)
 
@@ -17,9 +15,5 @@ if (outcome != success) of /subsystem=resource-adapters/resource-adapter=jackrab
 
   /subsystem=resource-adapters/resource-adapter=jackrabbit-jca.rar/connection-definitions=cfName/config-properties=HomeDir/:add(value=${JCR_HOME})
 
-  # Run the batch commands
-  run-batch
 end-if
-
-
 

--- a/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
+++ b/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
@@ -34,7 +34,7 @@ batch
 /subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_ERROR_LOG_HANDLER:add(level="ERROR",queue-length=1048576,overflow-action=BLOCK,subhandlers=["ERROR_LOG_FILE"])
 
 # Create a logger for Silverpeas: it will take all the texts coming from the Silverpeas root category.
-/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:add(level="INFO",handlers=[ASYNC_TRACE_LOG_HANDLER,ASYNC_ERROR_LOG_HANDLER])
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:add(level=${SILVERPEAS_LOGGING_LEVEL},handlers=[ASYNC_TRACE_LOG_HANDLER,ASYNC_ERROR_LOG_HANDLER])
 /subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:write-attribute(name=use-parent-handlers, value=false)
 
 # Create a logger for groups synchronization

--- a/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
+++ b/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
@@ -1,0 +1,49 @@
+#
+# Define a peculiar logging profile for Silverpeas in JBoss/Wildfly
+#
+
+if (outcome == success) of /subsystem=logging/logging-profile=silverpeas:read-resource
+  /subsystem=logging/logging-profile=silverpeas:remove
+end-if
+
+# Start batching commands
+batch
+
+# Add the logging profile Silverpeas
+/subsystem=logging/logging-profile=silverpeas:add
+
+# Add the periodic rotating file handlers
+# For global traces
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=TRACE_LOG_FILE:add(level="TRACE",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-trace.log"}, append=true)
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=TRACE_LOG_FILE:write-attribute(name=autoflush, value=true)
+
+# For errors
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=ERROR_LOG_FILE:add(level="ERROR",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-error.log"}, append=true)
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=ERROR_LOG_FILE:write-attribute(name=autoflush, value=true)
+
+# For groups synchronization with remote directory
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=GROUP_SYNC_LOG_FILE:add(level="INFO",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-group_sync.log"}, append=true)
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=GROUP_SYNC_LOG_FILE:write-attribute(name=autoflush, value=true)
+
+# For full domain synchronization with remote directory
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=DOMAIN_SYNC_LOG_FILE:add(level="INFO",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-domain_sync.log"}, append=true)
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=DOMAIN_SYNC_LOG_FILE:write-attribute(name=autoflush, value=true)
+
+# Configure the logging asynchronous handlers (by default they aren't used; they are defined in the case some users want asynchronous logging)
+/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_TRACE_LOG_HANDLER:add(level="TRACE",queue-length=1024,overflow-action=BLOCK,subhandlers=["TRACE_LOG_FILE"])
+/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_ERROR_LOG_HANDLER:add(level="ERROR",queue-length=1024,overflow-action=BLOCK,subhandlers=["ERROR_LOG_FILE"])
+
+# Create a logger for Silverpeas: it will take all the texts coming from the Silverpeas root category.
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:add(level="INFO",handlers=[TRACE_LOG_FILE,ERROR_LOG_FILE])
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:write-attribute(name=use-parent-handlers, value=false)
+
+# Create a logger for groups synchronization
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas.Core.Admin.SynchroGroup:add(level="INFO",handlers=[GROUP_SYNC_LOG_FILE])
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas.Core.Admin.SynchroGroup:write-attribute(name=use-parent-handlers, value=false)
+
+# Create a logger for domain synchronization
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas.Core.Admin.Synchro:add(level="${SILVERPEAS_LOGGING_LEVEL}",handlers=[DOMAIN_SYNC_LOG_FILE])
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas.Core.Admin.Synchro:write-attribute(name=use-parent-handlers, value=false)
+
+# Run the batch commands
+run-batch

--- a/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
+++ b/src/main/dist/configuration/jboss/silverpeas-logging-profile.cli
@@ -14,7 +14,7 @@ batch
 
 # Add the periodic rotating file handlers
 # For global traces
-/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=TRACE_LOG_FILE:add(level="TRACE",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-trace.log"}, append=true)
+/subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=TRACE_LOG_FILE:add(level="ALL",suffix=".yyyy.MM.dd", file={"path"=>"${SILVERPEAS_LOG}/silverpeas-trace.log"}, append=true)
 /subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=TRACE_LOG_FILE:write-attribute(name=autoflush, value=true)
 
 # For errors
@@ -30,11 +30,11 @@ batch
 /subsystem=logging/logging-profile=silverpeas/periodic-rotating-file-handler=DOMAIN_SYNC_LOG_FILE:write-attribute(name=autoflush, value=true)
 
 # Configure the logging asynchronous handlers (by default they aren't used; they are defined in the case some users want asynchronous logging)
-/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_TRACE_LOG_HANDLER:add(level="TRACE",queue-length=1024,overflow-action=BLOCK,subhandlers=["TRACE_LOG_FILE"])
-/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_ERROR_LOG_HANDLER:add(level="ERROR",queue-length=1024,overflow-action=BLOCK,subhandlers=["ERROR_LOG_FILE"])
+/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_TRACE_LOG_HANDLER:add(level="ALL",queue-length=1048576,overflow-action=BLOCK,subhandlers=["TRACE_LOG_FILE"])
+/subsystem=logging/logging-profile=silverpeas/async-handler=ASYNC_ERROR_LOG_HANDLER:add(level="ERROR",queue-length=1048576,overflow-action=BLOCK,subhandlers=["ERROR_LOG_FILE"])
 
 # Create a logger for Silverpeas: it will take all the texts coming from the Silverpeas root category.
-/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:add(level="INFO",handlers=[TRACE_LOG_FILE,ERROR_LOG_FILE])
+/subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:add(level="INFO",handlers=[ASYNC_TRACE_LOG_HANDLER,ASYNC_ERROR_LOG_HANDLER])
 /subsystem=logging/logging-profile=silverpeas/logger=Silverpeas:write-attribute(name=use-parent-handlers, value=false)
 
 # Create a logger for groups synchronization

--- a/src/main/dist/configuration/sample_config.properties
+++ b/src/main/dist/configuration/sample_config.properties
@@ -24,6 +24,9 @@
 # activates the multi-language for contents in Silverpeas. Accepts a coma-separated values among:
 # fr for French, en for English, and de for German
 #SILVERPEAS_CONTENT_LANGUAGES=fr
+# The default logging level for Silverpeas's loggers. A value among the following: DEBUG, INFO,
+# WARNING, ERROR.
+# SILVERPEAS_LOGGING_LEVEL=WARNING
 
 #
 # The properties to initialize the JVM

--- a/src/main/dist/configuration/silverpeas/00-SilverpeasSettings.xml
+++ b/src/main/dist/configuration/silverpeas/00-SilverpeasSettings.xml
@@ -33,6 +33,10 @@
       <parameter key="languages">${SILVERPEAS_CONTENT_LANGUAGES}</parameter>
     </configfile>
 
+    <configfile name="util/logging/silverpeasModule.properties">
+      <parameter key="module.level">${SILVERPEAS_LOGGING_LEVEL}</parameter>
+    </configfile>
+
     <configfile name="peasCore/SessionManager.properties">
       <parameter key="scheduledSessionManagementTimeStamp">2</parameter>
       <parameter key="userSessionTimeout">10</parameter>
@@ -103,17 +107,6 @@
       <parameter key="SMTPUser">${SMTP_USER}</parameter>
       <parameter key="SMTPPwd">${SMTP_PASSWORD}</parameter>
       <parameter key="SMTPSecure">${SMTP_SECURE}</parameter>
-    </configfile>
-
-    <configfile name="silvertrace/settings/silverLog.properties">
-       <parameter key="pathSilverLog">${SILVERPEAS_LOG}</parameter>
-       <parameter key="LogDir">${SILVERPEAS_LOG}</parameter>
-       <parameter key="appender0.fileName">${SILVERPEAS_LOG}/journal.txt</parameter>
-     </configfile>
-
-    <configfile name="silvertrace/settings/silverTrace.properties">
-      <parameter key="pathSilverTrace">${SILVERPEAS_HOME}/silvertrace</parameter>
-      <parameter key="ErrorDir">${SILVERPEAS_LOG}</parameter>
     </configfile>
 
     <configfile name="jobManagerPeas/settings/jobManagerPeasSettings.properties">


### PR DESCRIPTION
Replaces the old and flawed Silvertrace engine by a new logging engine that satisfies the usual logging API and uses in Java.
The new logging engine uses as logging backend the standard Java logging API and provides a specific logging API in the mind to wrap any logging implementation and to adhere to the logging use convention in Silverpeas.
Silvertrace is marked now as deprecated and it is in pending to be replaced by the new logging API. The implementation of Silvertrace has been removed and it uses now directly the new logging API.

Don't forget to merge also the PRs in Silverpeas-Core, Silverpeas-Components and Silverpeas-Setup.